### PR TITLE
fix(compose): change version declaration

### DIFF
--- a/container/compose.yaml
+++ b/container/compose.yaml
@@ -6,7 +6,7 @@ services:
       - "42420:42420/tcp"
       - "42420:42420/udp"
     environment:
-      - GAME_VERSION='1.19.8'
+      - GAME_VERSION=1.19.8
     volumes:
       - vintage-story-data:/home/vintagestory/data
       - vintage-story-server:/home/vintagestory/server


### PR DESCRIPTION
if u wrap version env in semicolon download requst failed with 404 because link now have semicolon

https://cdn.vintagestory.at/gamefiles/stable/vs_server_linux-x64_'1.19.8'.tar.gz